### PR TITLE
Bugfix: Correct `cv_rgb_image_layout`.

### DIFF
--- a/bubble-pop/source/AMD_app.cpp
+++ b/bubble-pop/source/AMD_app.cpp
@@ -229,10 +229,12 @@ int main(int argc, char **argv)
         cv_rgb_image_region.start_y    = 0;
         cv_rgb_image_region.end_x      = width;
         cv_rgb_image_region.end_y      = height;
-        vx_imagepatch_addressing_t cv_rgb_image_layout;
-        cv_rgb_image_layout.stride_x   = 3;
-        cv_rgb_image_layout.stride_y   = input_rgb.step;
-        vx_uint8 * cv_rgb_image_buffer = input_rgb.data;
+	vx_imagepatch_addressing_t cv_rgb_image_layout{};
+	cv_rgb_image_layout.dim_x = input.cols;
+	cv_rgb_image_layout.dim_y = input.rows;
+	cv_rgb_image_layout.stride_x = input.elemSize();
+	cv_rgb_image_layout.stride_y = input.step;
+	vx_uint8 * cv_rgb_image_buffer = input.data;
         ERROR_CHECK_STATUS( vxCopyImagePatch( input_rgb_image, &cv_rgb_image_region, 0,
                                             &cv_rgb_image_layout, cv_rgb_image_buffer,
                                             VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST ) );

--- a/bubble-pop/source/AMD_app.cpp
+++ b/bubble-pop/source/AMD_app.cpp
@@ -229,12 +229,12 @@ int main(int argc, char **argv)
         cv_rgb_image_region.start_y    = 0;
         cv_rgb_image_region.end_x      = width;
         cv_rgb_image_region.end_y      = height;
-	vx_imagepatch_addressing_t cv_rgb_image_layout{};
-	cv_rgb_image_layout.dim_x = input.cols;
-	cv_rgb_image_layout.dim_y = input.rows;
-	cv_rgb_image_layout.stride_x = input.elemSize();
-	cv_rgb_image_layout.stride_y = input.step;
-	vx_uint8 * cv_rgb_image_buffer = input.data;
+        vx_imagepatch_addressing_t cv_rgb_image_layout{};
+        cv_rgb_image_layout.dim_x = input_rgb.cols;
+        cv_rgb_image_layout.dim_y = input_rgb.rows;
+        cv_rgb_image_layout.stride_x = input_rgb.elemSize();
+        cv_rgb_image_layout.stride_y = input_rgb.step;
+        vx_uint8 * cv_rgb_image_buffer = input_rgb.data;
         ERROR_CHECK_STATUS( vxCopyImagePatch( input_rgb_image, &cv_rgb_image_region, 0,
                                             &cv_rgb_image_layout, cv_rgb_image_buffer,
                                             VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST ) );

--- a/canny-edge-detector/src/canny.cpp
+++ b/canny-edge-detector/src/canny.cpp
@@ -102,11 +102,11 @@ int main(int argc, char **argv)
         cv_rgb_image_region.end_x      = width;
         cv_rgb_image_region.end_y      = height;
         vx_imagepatch_addressing_t cv_rgb_image_layout{};
-	cv_rgb_image_layout.dim_x = input.cols;
-	cv_rgb_image_layout.dim_y = input.rows;
-	cv_rgb_image_layout.stride_x = input.elemSize();
-	cv_rgb_image_layout.stride_y = input.step;
-	vx_uint8 * cv_rgb_image_buffer = input.data;
+        cv_rgb_image_layout.dim_x = input_rgb.cols;
+        cv_rgb_image_layout.dim_y = input_rgb.rows;
+        cv_rgb_image_layout.stride_x = input_rgb.elemSize();
+        cv_rgb_image_layout.stride_y = input_rgb.step;
+        vx_uint8 * cv_rgb_image_buffer = input_rgb.data;
 	ERROR_CHECK_STATUS( vxCopyImagePatch( input_rgb_image, &cv_rgb_image_region, 0,
                                             &cv_rgb_image_layout, cv_rgb_image_buffer,
                                             VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST ) );

--- a/canny-edge-detector/src/canny.cpp
+++ b/canny-edge-detector/src/canny.cpp
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
         cv_rgb_image_layout.stride_x = input.elemSize();
         cv_rgb_image_layout.stride_y = input.step;
         vx_uint8 * cv_rgb_image_buffer = input.data;
-	ERROR_CHECK_STATUS( vxCopyImagePatch( input_rgb_image, &cv_rgb_image_region, 0,
+        ERROR_CHECK_STATUS( vxCopyImagePatch( input_rgb_image, &cv_rgb_image_region, 0,
                                             &cv_rgb_image_layout, cv_rgb_image_buffer,
                                             VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST ) );
         ERROR_CHECK_STATUS( vxProcessGraph( graph ) );

--- a/canny-edge-detector/src/canny.cpp
+++ b/canny-edge-detector/src/canny.cpp
@@ -102,11 +102,11 @@ int main(int argc, char **argv)
         cv_rgb_image_region.end_x      = width;
         cv_rgb_image_region.end_y      = height;
         vx_imagepatch_addressing_t cv_rgb_image_layout{};
-        cv_rgb_image_layout.dim_x = input_rgb.cols;
-        cv_rgb_image_layout.dim_y = input_rgb.rows;
-        cv_rgb_image_layout.stride_x = input_rgb.elemSize();
-        cv_rgb_image_layout.stride_y = input_rgb.step;
-        vx_uint8 * cv_rgb_image_buffer = input_rgb.data;
+        cv_rgb_image_layout.dim_x = input.cols;
+        cv_rgb_image_layout.dim_y = input.rows;
+        cv_rgb_image_layout.stride_x = input.elemSize();
+        cv_rgb_image_layout.stride_y = input.step;
+        vx_uint8 * cv_rgb_image_buffer = input.data;
 	ERROR_CHECK_STATUS( vxCopyImagePatch( input_rgb_image, &cv_rgb_image_region, 0,
                                             &cv_rgb_image_layout, cv_rgb_image_buffer,
                                             VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST ) );

--- a/canny-edge-detector/src/canny.cpp
+++ b/canny-edge-detector/src/canny.cpp
@@ -101,11 +101,13 @@ int main(int argc, char **argv)
         cv_rgb_image_region.start_y    = 0;
         cv_rgb_image_region.end_x      = width;
         cv_rgb_image_region.end_y      = height;
-        vx_imagepatch_addressing_t cv_rgb_image_layout;
-        cv_rgb_image_layout.stride_x   = 3;
-        cv_rgb_image_layout.stride_y   = input.step;
-        vx_uint8 * cv_rgb_image_buffer = input.data;
-        ERROR_CHECK_STATUS( vxCopyImagePatch( input_rgb_image, &cv_rgb_image_region, 0,
+        vx_imagepatch_addressing_t cv_rgb_image_layout{};
+	cv_rgb_image_layout.dim_x = input.cols;
+	cv_rgb_image_layout.dim_y = input.rows;
+	cv_rgb_image_layout.stride_x = input.elemSize();
+	cv_rgb_image_layout.stride_y = input.step;
+	vx_uint8 * cv_rgb_image_buffer = input.data;
+	ERROR_CHECK_STATUS( vxCopyImagePatch( input_rgb_image, &cv_rgb_image_region, 0,
                                             &cv_rgb_image_layout, cv_rgb_image_buffer,
                                             VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST ) );
         ERROR_CHECK_STATUS( vxProcessGraph( graph ) );

--- a/skin-tone-detector/src/skinToneDetector.cpp
+++ b/skin-tone-detector/src/skinToneDetector.cpp
@@ -159,12 +159,12 @@ int main(int argc, char **argv)
         cv_rgb_image_region.start_y    = 0;
         cv_rgb_image_region.end_x      = width;
         cv_rgb_image_region.end_y      = height;
-	vx_imagepatch_addressing_t cv_rgb_image_layout{};
-	cv_rgb_image_layout.dim_x = input.cols;
-	cv_rgb_image_layout.dim_y = input.rows;
-	cv_rgb_image_layout.stride_x = input.elemSize();
-	cv_rgb_image_layout.stride_y = input.step;
-	vx_uint8 * cv_rgb_image_buffer = input.data;
+        vx_imagepatch_addressing_t cv_rgb_image_layout{};
+        cv_rgb_image_layout.dim_x = input_rgb.cols;
+        cv_rgb_image_layout.dim_y = input_rgb.rows;
+        cv_rgb_image_layout.stride_x = input_rgb.elemSize();
+        cv_rgb_image_layout.stride_y = input_rgb.step;
+        vx_uint8 * cv_rgb_image_buffer = input_rgb.data;
         ERROR_CHECK_STATUS( vxCopyImagePatch( input_rgb_image, &cv_rgb_image_region, 0,
                                             &cv_rgb_image_layout, cv_rgb_image_buffer,
                                             VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST ) );

--- a/skin-tone-detector/src/skinToneDetector.cpp
+++ b/skin-tone-detector/src/skinToneDetector.cpp
@@ -159,10 +159,12 @@ int main(int argc, char **argv)
         cv_rgb_image_region.start_y    = 0;
         cv_rgb_image_region.end_x      = width;
         cv_rgb_image_region.end_y      = height;
-        vx_imagepatch_addressing_t cv_rgb_image_layout;
-        cv_rgb_image_layout.stride_x   = 3;
-        cv_rgb_image_layout.stride_y   = input_rgb.step;
-        vx_uint8 * cv_rgb_image_buffer = input_rgb.data;
+	vx_imagepatch_addressing_t cv_rgb_image_layout{};
+	cv_rgb_image_layout.dim_x = input.cols;
+	cv_rgb_image_layout.dim_y = input.rows;
+	cv_rgb_image_layout.stride_x = input.elemSize();
+	cv_rgb_image_layout.stride_y = input.step;
+	vx_uint8 * cv_rgb_image_buffer = input.data;
         ERROR_CHECK_STATUS( vxCopyImagePatch( input_rgb_image, &cv_rgb_image_region, 0,
                                             &cv_rgb_image_layout, cv_rgb_image_buffer,
                                             VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST ) );


### PR DESCRIPTION
The samples do not run on my machine (Intel OpenVX 2020.1, OpenCV 4.2).

Each sample's `vxCopyImagePatch` fails with `VX_ERROR_INVALID_PARAMETERS` because the image layout struct does not specify the dimensions of the image, or the `y_stride`.

This PR contains a patch which allowed the samples to run on my machine.